### PR TITLE
Support android share intent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ wormhole-william.release.apk: $(AAR)
 	$(APKSIGNER) sign --ks $(SIGNKEY) --out $@ wormhole-william-unsigned-aligned.apk
 	rm wormhole-william-unsigned-aligned.apk
 
-$(AAR): $(shell find . -name '*.go' -o -name '*.java' -type f)
+$(AAR): $(shell find . -name '*.go' -o -name '*.java' -o -name '*.xml' -type f)
 	mkdir -p $(@D)
 	go run gioui.org/cmd/gogio -buildmode archive -target android -minsdk 22 -appid io.sanford.wormhole_william -o $@ .
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -18,5 +18,14 @@
         <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
     </activity>
+    <activity
+        android:label="Wormhole William"
+        android:name="io.sanford.wormholewilliam.Share">
+      <intent-filter>
+        <action android:name="android.intent.action.SEND" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <data android:mimeType="*/*" />
+      </intent-filter>
+    </activity>
   </application>
 </manifest>

--- a/android/src/main/java/io/sanford/wormholewilliam/Download.java
+++ b/android/src/main/java/io/sanford/wormholewilliam/Download.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.lang.String;
 
 
-
 public class Download extends Fragment {
   private String path;
   private String name;

--- a/android/src/main/java/io/sanford/wormholewilliam/Jni.java
+++ b/android/src/main/java/io/sanford/wormholewilliam/Jni.java
@@ -85,7 +85,6 @@ public class Jni extends Fragment {
         }
       }
 
-
       String tmpFileName = String.valueOf(System.currentTimeMillis());
       File destFile = new File(cacheDir, tmpFileName);
 

--- a/android/src/main/java/io/sanford/wormholewilliam/Share.java
+++ b/android/src/main/java/io/sanford/wormholewilliam/Share.java
@@ -1,0 +1,110 @@
+package io.sanford.wormholewilliam;
+
+import android.app.Activity;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.Intent;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Parcelable;
+import android.provider.OpenableColumns;
+import android.util.Log;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.String;
+import org.gioui.Gio;
+import org.gioui.GioActivity;
+
+public class Share extends Activity {
+  public Share() {
+    Log.d("wormhole", "Share()");
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    Gio.init(this);
+
+		Intent intent = getIntent();
+    String action = intent.getAction();
+    String type = intent.getType();
+
+    if (type == null) {
+      finish();
+      return;
+    }
+
+    if (Intent.ACTION_SEND.equals(action)) {
+      if ("text/plain".equals(type)) {
+        String text = intent.getStringExtra(Intent.EXTRA_TEXT);
+        Intent openMainActivity = new Intent(this, GioActivity.class);
+        openMainActivity.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+        startActivityIfNeeded(openMainActivity, 0);
+        gotSharedItem("text", text, "");
+        finish();
+      } else if (intent.hasExtra(Intent.EXTRA_STREAM)) {
+        Uri uri = (Uri) intent.getParcelableExtra(Intent.EXTRA_STREAM);
+        handleGotSharedFile(uri);
+      }
+    }
+  }
+
+  private void handleGotSharedFile(Uri uri) {
+    String fileName = null;
+    ContentResolver contentResolver = getContentResolver();
+    try (Cursor cursor = contentResolver.query(uri, null, null, null, null, null)) {
+      if (cursor != null && cursor.moveToFirst()) {
+        int displayNameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
+        if (!cursor.isNull(displayNameIndex)) {
+          fileName = cursor.getString(displayNameIndex);
+        }
+      }
+    }
+
+    if (fileName == null) {
+      Log.d("wormhole", "Share got no filename");
+    }
+
+    String tmpFileName = String.valueOf(System.currentTimeMillis());
+    File destFile = new File(getCacheDir(), tmpFileName);
+
+    InputStream in = null;
+    FileOutputStream out = null;
+
+    try {
+      in = contentResolver.openInputStream(uri);
+      out = new FileOutputStream(destFile);
+
+      byte[] buffer = new byte[1024];
+      while (in.read(buffer) > 0) {
+        out.write(buffer);
+      }
+      out.close();
+      in.close();
+      Intent openMainActivity = new Intent(this, GioActivity.class);
+      openMainActivity.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+      startActivityIfNeeded(openMainActivity, 0);
+      gotSharedItem("file", destFile.getAbsolutePath(), fileName);
+      finish();
+      return;
+    } catch (Exception e) {
+      try {
+        if (in != null) {
+          in.close();
+        }
+        if (out != null) {
+          out.close();
+        }
+      } catch (IOException ignored) {}
+    }
+    Log.d("wormehole", "Share() read file error");
+    finish();
+  }
+
+  static private native void gotSharedItem(String type, String pathOrText, String filename);
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+type Config struct {
+	RendezvousURL string `json:"rendezvous_url"`
+	CodeLen       int    `json:"code_len"`
+	confFilename  string
+}
+
+func (c *Config) Save() error {
+	f, err := os.Create(c.confFilename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return json.NewEncoder(f).Encode(c)
+}
+
+func Load(dataDir string) *Config {
+	filename := filepath.Join(dataDir, "wormhole-william.json")
+	content, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return &Config{
+			confFilename: filename,
+		}
+	}
+
+	var conf Config
+	json.Unmarshal(content, &conf)
+	conf.confFilename = filename
+	return &conf
+}

--- a/internal/picker/picker.go
+++ b/internal/picker/picker.go
@@ -1,7 +1,21 @@
 package picker
 
+type SharedType int
+
+const (
+	File SharedType = 1
+	Text SharedType = 2
+)
+
 type PickResult struct {
 	Path string
 	Name string
 	Err  error
+}
+
+type SharedEvent struct {
+	Type SharedType
+	Path string
+	Name string
+	Text string
 }

--- a/ui/platform_android.go
+++ b/ui/platform_android.go
@@ -29,3 +29,7 @@ func (a *androidPlatform) notifyDownloadManager(name, path, contentType string, 
 	jgo.NotifyDownloadManager(a.viewEvent, name, path, contentType, size)
 
 }
+
+func (d *androidPlatform) sharedEventCh() chan picker.SharedEvent {
+	return jgo.GetSharedEventCh()
+}

--- a/ui/platform_dummy.go
+++ b/ui/platform_dummy.go
@@ -29,3 +29,7 @@ func (d *dummyPlatform) pickFile() <-chan picker.PickResult {
 
 func (d *dummyPlatform) notifyDownloadManager(name, path, contentType string, size int64) {
 }
+
+func (d *dummyPlatform) sharedEventCh() chan picker.SharedEvent {
+	return nil
+}


### PR DESCRIPTION
This adds initial support for android the share intent. Instead of
opening the app and choosing a file, you can share the file from a
different app.

The implementation is a little awkward. Normally you would receive
this intent in the main application activity. Gio owns that so we
can't do that in this case. So instead we make a new activity that
receives the event and then switches to the main activity.

Currently nothing prevents you from sharing from the UI and from a
share intent concurrently. The UI doesn't support this at all so the
first action will just disappear (although the messages will probably
get messed up).

We should add proper state management for this.

Fixes: #2