### PR TITLE
Support scanning QR Code for receiving files

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,4 +37,7 @@ android {
 
 dependencies {
     implementation ':wormhole-william@aar'
+    implementation 'com.android.support:appcompat-v7:26.1.0'
+    compile 'com.google.zxing:core:3.2.1'
+    compile 'com.journeyapps:zxing-android-embedded:3.2.0@aar'
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="io.sanford.wormhole_william">
+          package="io.sanford.wormhole_william"
+          xmlns:tools="http://schemas.android.com/tools"
+          >
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
@@ -28,5 +30,13 @@
         <data android:mimeType="*/*" />
       </intent-filter>
     </activity>
+
+    <activity
+        android:name="com.journeyapps.barcodescanner.CaptureActivity"
+        android:screenOrientation="portrait"
+        tools:replace="android:screenOrientation"
+        android:stateNotNeeded="true">
+    </activity>
+
   </application>
 </manifest>

--- a/android/src/main/java/io/sanford/wormholewilliam/Scan.java
+++ b/android/src/main/java/io/sanford/wormholewilliam/Scan.java
@@ -1,0 +1,54 @@
+package io.sanford.wormholewilliam;
+
+import android.app.Activity;
+import android.app.Fragment;
+import android.app.FragmentTransaction;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Handler;
+import android.util.Log;
+import android.view.View;
+import com.google.zxing.integration.android.IntentIntegrator;
+import com.google.zxing.integration.android.IntentResult;
+import java.lang.String;
+
+public class Scan extends Fragment {
+  public Scan() {
+  }
+
+  public void register(View view) {
+    Context ctx = view.getContext();
+    Handler handler = new Handler(ctx.getMainLooper());
+    Scan inst = this;
+    handler.post(new Runnable() {
+        public void run() {
+          Activity act = (Activity)ctx;
+          FragmentTransaction ft = act.getFragmentManager().beginTransaction();
+          ft.add(inst, "Scan");
+          ft.commitNow();
+        }
+      });
+  }
+
+  @Override public void onAttach(Context ctx) {
+    super.onAttach(ctx);
+
+    IntentIntegrator integrator = IntentIntegrator.forFragment(this);
+    integrator.setDesiredBarcodeFormats(IntentIntegrator.QR_CODE_TYPES);
+    integrator.setPrompt("Scan");
+    integrator.setCameraId(0);
+    integrator.setBeepEnabled(false);
+    integrator.setBarcodeImageEnabled(false);
+    integrator.initiateScan();
+  }
+
+  @Override public void onActivityResult(int requestCode, int resultCode, Intent data) {
+    IntentResult result = IntentIntegrator.parseActivityResult(requestCode, resultCode, data);
+    if(result != null) {
+      Log.d("wormhole", "Scan.onActivityResult() " + result.getContents());
+      scanResult(result.getContents());
+    }
+  }
+
+  static private native void scanResult(String contents);
+}

--- a/ui/platform_android.go
+++ b/ui/platform_android.go
@@ -30,6 +30,10 @@ func (a *androidPlatform) notifyDownloadManager(name, path, contentType string, 
 
 }
 
-func (d *androidPlatform) sharedEventCh() chan picker.SharedEvent {
+func (a *androidPlatform) sharedEventCh() chan picker.SharedEvent {
 	return jgo.GetSharedEventCh()
+}
+
+func (a *androidPlatform) scanQRCode() <-chan string {
+	return jgo.ScanQRCode(a.viewEvent)
 }

--- a/ui/platform_dummy.go
+++ b/ui/platform_dummy.go
@@ -33,3 +33,7 @@ func (d *dummyPlatform) notifyDownloadManager(name, path, contentType string, si
 func (d *dummyPlatform) sharedEventCh() chan picker.SharedEvent {
 	return nil
 }
+
+func (d *dummyPlatform) scanQRCode() <-chan string {
+	return nil
+}


### PR DESCRIPTION
QR Codes can be generated from the wormwhole-william cli tool via the
`--qr` flag.

The code embeds the relay url, but currently we are ignoring that and
just using the relay set in the config.