### PR TITLE
Fix download access for android 10

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
   <uses-feature android:glEsVersion="0x00020000" android:required="false"/>
   <uses-feature android:name="android.hardware.type.pc" android:required="false"/>
 
-  <application android:label="Wormhole William" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round">
+  <application android:label="Wormhole William" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:requestLegacyExternalStorage="true">
     <activity
         android:configChanges="keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
         android:label="Wormhole William"

--- a/android/src/main/java/io/sanford/wormholewilliam/WriteFilePerm.java
+++ b/android/src/main/java/io/sanford/wormholewilliam/WriteFilePerm.java
@@ -1,0 +1,75 @@
+package io.sanford.wormholewilliam;
+
+import android.Manifest;
+import android.app.Activity;
+import android.app.Fragment;
+import android.app.FragmentTransaction;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Handler;
+import android.util.Log;
+import android.view.View;
+import java.lang.String;
+
+
+public class WriteFilePerm extends Fragment {
+  final int PERMISSION_REQUEST = 1;
+
+  public WriteFilePerm() {
+    Log.d("wormhole", "WriteFilePerm()");
+  }
+
+  public void register(View view) {
+    Log.d("wormhole", "WriteFilePerm: register()");
+    Context ctx = view.getContext();
+    Handler handler = new Handler(ctx.getMainLooper());
+    WriteFilePerm inst = this;
+    handler.post(new Runnable() {
+        public void run() {
+          Activity act = (Activity)ctx;
+          FragmentTransaction ft = act.getFragmentManager().beginTransaction();
+          ft.add(inst, "WriteFilePerm");
+          ft.commitNow();
+        }
+      });
+  }
+
+  @Override public void onAttach(Context ctx) {
+    super.onAttach(ctx);
+    Log.d("wormhole", "WireFilePerm: onAttach()");
+    if (ctx.checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+      requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, PERMISSION_REQUEST);
+    } else {
+      permissionResult(true);
+    }
+  }
+
+  @Override
+  public void onDestroy() {
+    Log.d("wormhole", "WriteFilePerm: onDestroy()");
+    super.onDestroy();
+  }
+
+  @Override
+  public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+    Log.d("wormhole", "WireFilePerm: onRequestPermissionsResult");
+    if (requestCode == PERMISSION_REQUEST) {
+      boolean granted = true;
+      for (int x : grantResults) {
+        if (x == PackageManager.PERMISSION_DENIED) {
+          granted = false;
+          break;
+        }
+      }
+      if (!granted) {
+        Log.d("wormhole", "WireFilePerm: permissions not granted");
+      } else{
+        Log.d("wormhole", "WireFilePerm: permissions granted");
+      }
+
+      permissionResult(granted);
+    }
+  }
+
+  static private native void permissionResult(boolean allowed);
+}

--- a/internal/picker/picker.go
+++ b/internal/picker/picker.go
@@ -19,3 +19,8 @@ type SharedEvent struct {
 	Name string
 	Text string
 }
+
+type PermResult struct {
+	Authorized bool
+	Err        error
+}

--- a/ui/platform_android.go
+++ b/ui/platform_android.go
@@ -29,11 +29,14 @@ func (a *androidPlatform) notifyDownloadManager(name, path, contentType string, 
 	jgo.NotifyDownloadManager(a.viewEvent, name, path, contentType, size)
 
 }
-
 func (a *androidPlatform) sharedEventCh() chan picker.SharedEvent {
 	return jgo.GetSharedEventCh()
 }
 
 func (a *androidPlatform) scanQRCode() <-chan string {
 	return jgo.ScanQRCode(a.viewEvent)
+}
+
+func (a *androidPlatform) requestWriteFilePerm() <-chan picker.PermResult {
+	return jgo.RequestWriteFilePermission(a.viewEvent)
 }

--- a/ui/platform_dummy.go
+++ b/ui/platform_dummy.go
@@ -37,3 +37,12 @@ func (d *dummyPlatform) sharedEventCh() chan picker.SharedEvent {
 func (d *dummyPlatform) scanQRCode() <-chan string {
 	return nil
 }
+
+func (d *dummyPlatform) requestWriteFilePerm() <-chan picker.PermResult {
+	ch := make(chan picker.PermResult, 1)
+	ch <- picker.PermResult{
+		Authorized: true,
+	}
+
+	return ch
+}


### PR DESCRIPTION
For android 10 we need `requestLegacyExternalStorage` and we need
WRITE_EXTERNAL_STORAGE.

We now will prompt for WRITE_EXTERNAL_STORAGE after you click
accept (if we don't already have it).

I'm not really sure why this works on android 11 but fails on android
10.