### PR TITLE
Adds QR code generation for sends

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,5 +15,6 @@ require (
 	golang.org/x/exp/shiny v0.0.0-20220827204233-334a2380cb91
 	google.golang.org/protobuf v1.27.1 // indirect
 	nhooyr.io/websocket v1.8.7 // indirect
+	rsc.io/qr v0.2.0
 	salsa.debian.org/vasudev/gospake2 v0.0.0-20210510093858-d91629950ad1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -676,6 +676,7 @@ nhooyr.io/websocket v1.8.6/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0
 nhooyr.io/websocket v1.8.7 h1:usjR2uOr/zjjkVMy0lW+PPohFok7PCow5sDjLgX4P4g=
 nhooyr.io/websocket v1.8.7/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
+rsc.io/qr v0.2.0 h1:6vBLea5/NRMVTz8V66gipeLycZMl/+UlFmk8DvqQ6WY=
 rsc.io/qr v0.2.0/go.mod h1:IF+uZjkb9fqyeF/4tlBoynqmQxUoPfWEKh921coOuXs=
 salsa.debian.org/vasudev/gospake2 v0.0.0-20180813171123-adcc69dd31d5/go.mod h1:soKzqXBAtqHTODjyA0VzH2iERtpzN1w65eZUfetn2cQ=
 salsa.debian.org/vasudev/gospake2 v0.0.0-20210510093858-d91629950ad1 h1:m65DhEZR/5zbgOGW4sQGDZmIwro+xBGIBQGWm43SlxM=


### PR DESCRIPTION
This implements #28. I've done *no* testing on mobile, but:

1. It uses a QR library from rsc, which has no C dependencies
2. It works running the patched app on my laptop, generating QR codes, and receiving (by scannang the codes) from the wormhole-william-mobile app on my phone
3. I have no reason to expect -- given the simplicity of my changes, and of rsc's QR library -- that it won't work once it's on a mobile device

The QR codes are small, but they scan, and it works as-is. I don't have the Android SDK currently installed on my laptop because it's enormous.

Anyhoo, you said you'd be happy to have a patch for #28, so here it is.