### PR TITLE
Upgrade zxing library

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.2'
@@ -11,7 +11,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         flatDir {
             dirs 'libs'
         }
@@ -26,7 +26,7 @@ android {
     buildToolsVersion "33.0.2"
     compileSdkVersion 30
     defaultConfig {
-        minSdkVersion 22
+        minSdkVersion 24
         targetSdkVersion 34
         versionCode 18
         versionName "1.0.13"
@@ -39,7 +39,6 @@ android {
 
 dependencies {
     implementation ':wormhole-william@aar'
-    implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.google.zxing:core:3.2.1'
-    implementation 'com.journeyapps:zxing-android-embedded:3.2.0@aar'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'com.journeyapps:zxing-android-embedded:4.3.0'
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+

--- a/android/src/main/java/io/sanford/wormholewilliam/Scan.java
+++ b/android/src/main/java/io/sanford/wormholewilliam/Scan.java
@@ -32,9 +32,8 @@ public class Scan extends Fragment {
 
   @Override public void onAttach(Context ctx) {
     super.onAttach(ctx);
-
     IntentIntegrator integrator = IntentIntegrator.forFragment(this);
-    integrator.setDesiredBarcodeFormats(IntentIntegrator.QR_CODE_TYPES);
+    integrator.setDesiredBarcodeFormats(IntentIntegrator.QR_CODE);
     integrator.setPrompt("Scan");
     integrator.setCameraId(0);
     integrator.setBeepEnabled(false);


### PR DESCRIPTION
This is needed to be able to perform fresh builds. jcenter is gone which means we can't fetch our older zxing dependency anymore.

zxing now requires androidx so use that for the compat library.

The docs for zxing say that this version requires at least sdk 24 so bump our min version to that.