### PR TITLE
Add magic-wormhole QR code scheme support

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -943,6 +943,8 @@ func parseCodeURI(codeStr string) (*parsedCode, error) {
 	} else if strings.HasPrefix(codeStr, "wormhole-transfer:") {
 		// magic-wormhole URI Scheme
 		code := strings.TrimPrefix(codeStr, "wormhole-transfer:")
+		parts := strings.Split(code, "?") // remove query params if they exists
+		code = parts[0]
 		code, err := url.QueryUnescape(code)
 		if err != nil {
 			return nil, err

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -51,3 +51,13 @@ func TestParsingMagicWormholeUriPercentEncoded(t *testing.T) {
 		t.Errorf("got %s, %v expected %s", parsed.code, err, unencodedCode)
 	}
 }
+
+func TestParsingMagicWormholeUriWithQueryParams(t *testing.T) {
+	uri := "wormhole-transfer:" + expectedCode + "?version=0&rendezvous=ws%3A%2F%2Frelay.magic-wormhole.io%3A4000&role=follower"
+
+	parsed, err := parseCodeURI(uri)
+
+	if parsed.code != expectedCode || err != nil {
+		t.Errorf("got %s, %v, expected %s", parsed.code, err, expectedCode)
+	}
+}


### PR DESCRIPTION
Hi, thanks for your work.

This PR add support for the new `magic-wormhole` QR code scheme #47.
It does not cover the [optional query fields](https://github.com/magic-wormhole/magic-wormhole-protocols/blob/main/uri-scheme.md#query-fields). But I don't think the app can use these fields at the moment anyway.

Tested with android 11 and magic-wormhole 0.20.0 (latest).