### PR TITLE
Show app version on the Settings screen

### DIFF
--- a/android/app/src/main/kotlin/io/sanford/wormhole_william/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/io/sanford/wormhole_william/ui/screens/SettingsScreen.kt
@@ -15,9 +15,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import androidx.core.content.pm.PackageInfoCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.sanford.wormhole_william.ui.viewmodel.SettingsViewModel
 
@@ -27,6 +30,17 @@ fun SettingsScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val scrollState = rememberScrollState()
+    val context = LocalContext.current
+    val versionLabel = remember {
+        try {
+            val info = context.packageManager.getPackageInfo(context.packageName, 0)
+            val name = info.versionName ?: "?"
+            val code = PackageInfoCompat.getLongVersionCode(info)
+            "$name ($code)"
+        } catch (e: Exception) {
+            ""
+        }
+    }
 
     Column(
         modifier = Modifier
@@ -87,6 +101,22 @@ fun SettingsScreen(
         Text(
             text = "Number of words in the generated code. Default is 2.",
             style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // About
+        Text(
+            text = "About",
+            style = MaterialTheme.typography.titleLarge
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = if (versionLabel.isNotEmpty()) "Version $versionLabel" else "Version unavailable",
+            style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
     }


### PR DESCRIPTION
## What

Adds an "About" section to the Settings screen showing the app version.

## Why

The app did not display its version anywhere, not even in Settings, so there was no way to tell which build was installed.

## Details

- Shows versionName and versionCode, read at runtime via PackageManager. This avoids a dependency on BuildConfig, which is not enabled for this module.
- Falls back to "Version unavailable" if the lookup fails.
