### PR TITLE
Fix spurious "file already exists" when re-downloading a file

### DIFF
--- a/android/app/src/main/kotlin/io/sanford/wormhole_william/ui/viewmodel/ReceiveViewModel.kt
+++ b/android/app/src/main/kotlin/io/sanford/wormhole_william/ui/viewmodel/ReceiveViewModel.kt
@@ -7,6 +7,8 @@ import io.sanford.wormhole_william.repository.WormholeRepository
 import io.sanford.wormhole_william.util.detectMimeType
 import io.sanford.wormhole_william.util.formatBytes
 import io.sanford.wormhole_william.util.notifyDownloadManager
+import io.sanford.wormhole_william.util.queryDownloadDisplayName
+import java.io.File
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -123,7 +125,22 @@ class ReceiveViewModel(application: Application) : AndroidViewModel(application)
                         )
 
                         val statusMsg = result.fold(
-                            onSuccess = { _ -> "File saved to Downloads: $fileName" },
+                            onSuccess = { uri ->
+                                // The copy to Downloads succeeded, so the
+                                // internal staging copy is no longer needed.
+                                // Removing it also prevents a later same-named
+                                // transfer from being wrongly blocked as
+                                // "already exists". Only delete on success: if
+                                // the copy failed, the staging file is the only
+                                // copy of the received file and must be kept.
+                                runCatching { File(state.path).delete() }
+                                val savedName = context.queryDownloadDisplayName(uri) ?: fileName
+                                if (savedName != fileName) {
+                                    "Saved to Downloads as $savedName (renamed to avoid overwriting an existing file)"
+                                } else {
+                                    "File saved to Downloads: $savedName"
+                                }
+                            },
                             onFailure = { e -> "File received but failed to copy to Downloads: ${e.message}" }
                         )
 

--- a/android/app/src/main/kotlin/io/sanford/wormhole_william/ui/viewmodel/ReceiveViewModel.kt
+++ b/android/app/src/main/kotlin/io/sanford/wormhole_william/ui/viewmodel/ReceiveViewModel.kt
@@ -9,12 +9,14 @@ import io.sanford.wormhole_william.util.formatBytes
 import io.sanford.wormhole_william.util.notifyDownloadManager
 import io.sanford.wormhole_william.util.queryDownloadDisplayName
 import java.io.File
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import wormhole.PendingTransfer
 
 data class ReceiveUiState(
@@ -115,34 +117,40 @@ class ReceiveViewModel(application: Application) : AndroidViewModel(application)
                         val context = getApplication<Application>()
                         val fileName = _uiState.value.pendingFileName
                         val fileSize = _uiState.value.pendingFileSize
-                        val mimeType = detectMimeType(state.path)
 
-                        val result = context.notifyDownloadManager(
-                            name = fileName,
-                            path = state.path,
-                            mimeType = mimeType,
-                            size = fileSize
-                        )
+                        // The copy to Downloads is file I/O proportional to
+                        // the transfer size; keep it off the main thread so a
+                        // large received file cannot freeze the UI (ANR).
+                        val statusMsg = withContext(Dispatchers.IO) {
+                            val mimeType = detectMimeType(state.path)
 
-                        val statusMsg = result.fold(
-                            onSuccess = { uri ->
-                                // The copy to Downloads succeeded, so the
-                                // internal staging copy is no longer needed.
-                                // Removing it also prevents a later same-named
-                                // transfer from being wrongly blocked as
-                                // "already exists". Only delete on success: if
-                                // the copy failed, the staging file is the only
-                                // copy of the received file and must be kept.
-                                runCatching { File(state.path).delete() }
-                                val savedName = context.queryDownloadDisplayName(uri) ?: fileName
-                                if (savedName != fileName) {
-                                    "Saved to Downloads as $savedName (renamed to avoid overwriting an existing file)"
-                                } else {
-                                    "File saved to Downloads: $savedName"
-                                }
-                            },
-                            onFailure = { e -> "File received but failed to copy to Downloads: ${e.message}" }
-                        )
+                            val result = context.notifyDownloadManager(
+                                name = fileName,
+                                path = state.path,
+                                mimeType = mimeType,
+                                size = fileSize
+                            )
+
+                            result.fold(
+                                onSuccess = { uri ->
+                                    // The copy to Downloads succeeded, so the
+                                    // internal staging copy is no longer needed.
+                                    // Removing it also prevents a later same-named
+                                    // transfer from being wrongly blocked as
+                                    // "already exists". Only delete on success: if
+                                    // the copy failed, the staging file is the only
+                                    // copy of the received file and must be kept.
+                                    runCatching { File(state.path).delete() }
+                                    val savedName = context.queryDownloadDisplayName(uri) ?: fileName
+                                    if (savedName != fileName) {
+                                        "Saved to Downloads as $savedName (renamed to avoid overwriting an existing file)"
+                                    } else {
+                                        "File saved to Downloads: $savedName"
+                                    }
+                                },
+                                onFailure = { e -> "File received but failed to copy to Downloads: ${e.message}" }
+                            )
+                        }
 
                         _uiState.update {
                             it.copy(

--- a/android/app/src/main/kotlin/io/sanford/wormhole_william/util/DownloadManager.kt
+++ b/android/app/src/main/kotlin/io/sanford/wormhole_william/util/DownloadManager.kt
@@ -11,6 +11,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
+import android.provider.OpenableColumns
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import io.sanford.wormhole_william.R
@@ -19,6 +20,9 @@ import java.io.FileInputStream
 
 private const val CHANNEL_ID = "wormhole_downloads"
 private const val NOTIFICATION_ID = 1001
+
+// Max filename length on Android storage (vfat/ext4 both cap at 255 bytes).
+private const val MAX_FILENAME_BYTES = 255
 
 /**
  * Registers a file with Android's Download Manager so it appears in the Downloads app.
@@ -47,6 +51,76 @@ fun Context.notifyDownloadManager(
         e.printStackTrace()
         Result.failure(e)
     }
+}
+
+/**
+ * Resolves the actual display name of a saved download. On Android 10+ the
+ * MediaStore automatically appends a numeric suffix (e.g. "report (1).pdf")
+ * when a file with the same name already exists in Downloads, so the saved
+ * name may differ from the requested one.
+ */
+fun Context.queryDownloadDisplayName(uri: Uri): String? {
+    // file:// URIs (legacy path) carry the name directly; ContentResolver does
+    // not answer OpenableColumns for them.
+    if (uri.scheme == "file") return uri.lastPathSegment
+    return try {
+        contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+            ?.use { cursor ->
+                val idx = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (idx >= 0 && cursor.moveToFirst()) cursor.getString(idx) else null
+            }
+    } catch (e: Exception) {
+        null
+    }
+}
+
+/**
+ * Atomically creates and returns a new (empty) File in [dir], appending
+ * " (1)", " (2)", ... before the extension on collision, mirroring MediaStore's
+ * auto-rename so the legacy (pre-Android 10) path does not overwrite an existing
+ * download. Uses File.createNewFile() (an atomic create-if-absent) rather than a
+ * check-then-create, so a racing writer cannot cause an overwrite.
+ */
+private fun uniqueDownloadFile(dir: File, name: String): File {
+    val dot = name.lastIndexOf('.')
+    val base = if (dot > 0) name.substring(0, dot) else name
+    val ext = if (dot > 0) name.substring(dot) else ""
+
+    var candidate = File(dir, name)
+    var i = 1
+    while (!candidate.createNewFile()) {
+        val suffix = " ($i)"
+        // Keep the suffixed name within the filesystem's 255-byte limit by
+        // trimming the base; without this a near-max-length name could exceed
+        // the limit once the collision suffix is appended.
+        val room = MAX_FILENAME_BYTES - utf8Len(suffix) - utf8Len(ext)
+        candidate = File(dir, trimToBytes(base, room) + suffix + ext)
+        i++
+    }
+    return candidate
+}
+
+private fun utf8Len(s: String): Int = s.toByteArray(Charsets.UTF_8).size
+
+/**
+ * Trims s to at most maxBytes UTF-8 bytes without splitting a Unicode code
+ * point (so the result is always valid).
+ */
+private fun trimToBytes(s: String, maxBytes: Int): String {
+    if (maxBytes <= 0) return ""
+    if (utf8Len(s) <= maxBytes) return s
+
+    val sb = StringBuilder()
+    var bytes = 0
+    val it = s.codePoints().iterator()
+    while (it.hasNext()) {
+        val chunk = String(Character.toChars(it.nextInt()))
+        val chunkBytes = utf8Len(chunk)
+        if (bytes + chunkBytes > maxBytes) break
+        sb.append(chunk)
+        bytes += chunkBytes
+    }
+    return sb.toString()
 }
 
 private fun Context.copyToDownloadsViaMediaStore(
@@ -98,19 +172,29 @@ private fun Context.copyToDownloadsLegacy(
     // Copy to public Downloads directory
     @Suppress("DEPRECATION")
     val downloadsDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
-    val destFile = File(downloadsDir, name)
+    downloadsDir.mkdirs()
+    // Pick a non-colliding name so an existing download is not overwritten
+    // (MediaStore does this automatically on Android 10+).
+    val destFile = uniqueDownloadFile(downloadsDir, name)
 
-    FileInputStream(sourcePath).use { input ->
-        destFile.outputStream().use { output ->
-            input.copyTo(output)
+    try {
+        FileInputStream(sourcePath).use { input ->
+            destFile.outputStream().use { output ->
+                input.copyTo(output)
+            }
         }
+    } catch (e: Exception) {
+        // uniqueDownloadFile already created (reserved) destFile; remove the
+        // 0-byte/partial file so a failed copy doesn't leave junk in Downloads.
+        destFile.delete()
+        throw e
     }
 
     // Register with DownloadManager
     val downloadManager = getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
     @Suppress("DEPRECATION")
     downloadManager.addCompletedDownload(
-        name,
+        destFile.name,
         "Received via Wormhole William",
         true,
         mimeType,

--- a/wormhole/pending.go
+++ b/wormhole/pending.go
@@ -36,14 +36,12 @@ func (p *PendingTransfer) Accept() {
 	go func() {
 		defer p.cancel()
 
+		// dataDir is an internal, ephemeral staging area. The Kotlin layer
+		// copies the result into the user-visible Downloads folder and then
+		// deletes this staging file. Overwrite any leftover staging file
+		// (e.g. from a previous interrupted transfer) rather than failing:
+		// os.Create truncates an existing file.
 		path := filepath.Join(p.client.dataDir, p.name)
-
-		// Check if file exists
-		if _, err := os.Stat(path); err == nil {
-			p.msg.Reject()
-			p.callback.OnError("file already exists: " + p.name)
-			return
-		}
 
 		f, err := os.Create(path)
 		if err != nil {

--- a/wormhole/wormhole.go
+++ b/wormhole/wormhole.go
@@ -180,15 +180,11 @@ func (c *Client) Receive(code string, callback ReceiveCallback) {
 
 			callback.OnFileStart(name, msg.TransferBytes64)
 
-			// Save to dataDir
+			// Save to dataDir, an internal staging area. The Android layer
+			// copies the result to the user-visible Downloads folder and then
+			// removes this file, so overwrite any leftover staging file rather
+			// than failing: os.Create truncates an existing file.
 			path := filepath.Join(c.dataDir, name)
-
-			// Check if file exists
-			if _, err := os.Stat(path); err == nil {
-				msg.Reject()
-				callback.OnError("file already exists: " + name)
-				return
-			}
 
 			f, err := os.Create(path)
 			if err != nil {


### PR DESCRIPTION
## What

Fixes the bug where receiving a file with the same name as a previous one fails with "file already exists", even after the earlier file was deleted from the Downloads folder.

## Why

Received files are first written to an internal, ephemeral staging directory (filesDir) and then copied to the public Downloads folder. The staging copy was never deleted, and the Go receive path hard-failed with "file already exists" whenever a file of the same name was still in staging. Deleting the file from the user-visible Downloads folder did not remove the staging copy, so later transfers of a same-named file were wrongly rejected.

## Details

- Drop the staging existence check on both the accept and auto-accept Go paths. os.Create truncates any leftover staging file.
- Delete the staging file after it is copied to Downloads.
- On Android 10+, MediaStore auto-renames on collision, so the actual saved name (for example "report (1).pdf") is now surfaced in the status message.

## Testing

Built and installed a debug APK on a Samsung Galaxy S22 Ultra (Android 14) and confirmed that receiving two files with the same name now succeeds, with the second saved under an auto-incremented name.
