### PR TITLE
Replace ZXing QR scanner with CameraX + ML Kit

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -84,8 +84,18 @@ dependencies {
     // DataStore for preferences
     implementation("androidx.datastore:datastore-preferences:1.0.0")
 
-    // QR code scanning (ZXing)
-    implementation("com.journeyapps:zxing-android-embedded:4.3.0")
+    // QR code generation (ZXing core only)
+    implementation("com.google.zxing:core:3.5.3")
+
+    // QR code scanning (CameraX + ML Kit). ZXing's Camera1 scanner fails to
+    // decode on some modern high-resolution sensors (e.g. Samsung S22 Ultra),
+    // so scanning uses ML Kit on CameraX (Camera2) instead.
+    val cameraxVersion = "1.3.4"
+    implementation("androidx.camera:camera-core:$cameraxVersion")
+    implementation("androidx.camera:camera-camera2:$cameraxVersion")
+    implementation("androidx.camera:camera-lifecycle:$cameraxVersion")
+    implementation("androidx.camera:camera-view:$cameraxVersion")
+    implementation("com.google.mlkit:barcode-scanning:17.2.0")
 
     // Testing
     testImplementation("junit:junit:4.13.2")

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -45,13 +45,6 @@
             </intent-filter>
         </activity>
 
-        <!-- ZXing QR Scanner Activity -->
-        <activity
-            android:name="com.journeyapps.barcodescanner.CaptureActivity"
-            android:screenOrientation="portrait"
-            android:stateNotNeeded="true"
-            tools:replace="android:screenOrientation" />
-
         <!-- File Provider for sharing files -->
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/android/app/src/main/kotlin/io/sanford/wormhole_william/WormholeApp.kt
+++ b/android/app/src/main/kotlin/io/sanford/wormhole_william/WormholeApp.kt
@@ -1,6 +1,5 @@
 package io.sanford.wormhole_william
 
-import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -29,6 +28,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -39,7 +39,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import io.sanford.wormhole_william.ui.ScanQRCodeContract
+import io.sanford.wormhole_william.ui.QrScannerScreen
 import io.sanford.wormhole_william.ui.parseWormholeUri
 import io.sanford.wormhole_william.ui.screens.ReceiveScreen
 import io.sanford.wormhole_william.ui.screens.SendFileScreen
@@ -76,21 +76,26 @@ fun WormholeApp(
     // Shared ReceiveViewModel so QR scanner can set the code
     val receiveViewModel: ReceiveViewModel = viewModel()
 
-    // QR code scanner launcher
-    val qrScannerLauncher = rememberLauncherForActivityResult(
-        contract = ScanQRCodeContract()
-    ) { result ->
-        result?.let { scannedContent ->
-            // Parse the QR code content
-            val parsed = parseWormholeUri(scannedContent)
-            if (parsed != null) {
-                parsed.rendezvousUrl?.let { receiveViewModel.setRendezvousUrl(it) }
-                receiveViewModel.setCode(parsed.code)
-            } else {
-                // Fall back to using raw content as code
-                receiveViewModel.setCode(scannedContent)
-            }
-        }
+    // Whether the full-screen QR scanner overlay is showing.
+    var showScanner by remember { mutableStateOf(false) }
+
+    if (showScanner) {
+        QrScannerScreen(
+            onResult = { scannedContent ->
+                showScanner = false
+                // Parse the QR code content
+                val parsed = parseWormholeUri(scannedContent)
+                if (parsed != null) {
+                    parsed.rendezvousUrl?.let { receiveViewModel.setRendezvousUrl(it) }
+                    receiveViewModel.setCode(parsed.code)
+                } else {
+                    // Fall back to using raw content as code
+                    receiveViewModel.setCode(scannedContent)
+                }
+            },
+            onClose = { showScanner = false }
+        )
+        return
     }
 
     Scaffold(
@@ -145,7 +150,7 @@ fun WormholeApp(
             when (selectedTab) {
                 0 -> ReceiveScreen(
                     viewModel = receiveViewModel,
-                    onScanQR = { qrScannerLauncher.launch(Unit) }
+                    onScanQR = { showScanner = true }
                 )
                 1 -> SendTextScreen(initialText = (initialShare as? SharedData.Text)?.content)
                 2 -> SendFileScreen(initialFileUri = (initialShare as? SharedData.File)?.uri)

--- a/android/app/src/main/kotlin/io/sanford/wormhole_william/WormholeApp.kt
+++ b/android/app/src/main/kotlin/io/sanford/wormhole_william/WormholeApp.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -76,8 +77,9 @@ fun WormholeApp(
     // Shared ReceiveViewModel so QR scanner can set the code
     val receiveViewModel: ReceiveViewModel = viewModel()
 
-    // Whether the full-screen QR scanner overlay is showing.
-    var showScanner by remember { mutableStateOf(false) }
+    // Whether the full-screen QR scanner overlay is showing. Saveable so a
+    // configuration change (e.g. rotation) mid-scan does not close the scanner.
+    var showScanner by rememberSaveable { mutableStateOf(false) }
 
     if (showScanner) {
         QrScannerScreen(

--- a/android/app/src/main/kotlin/io/sanford/wormhole_william/ui/QRScanner.kt
+++ b/android/app/src/main/kotlin/io/sanford/wormhole_william/ui/QRScanner.kt
@@ -1,33 +1,6 @@
 package io.sanford.wormhole_william.ui
 
-import android.app.Activity
-import android.content.Context
-import android.content.Intent
-import androidx.activity.result.contract.ActivityResultContract
-import com.google.zxing.integration.android.IntentIntegrator
-import com.google.zxing.integration.android.IntentResult
 import java.net.URLDecoder
-
-/**
- * Activity Result Contract for ZXing QR code scanning.
- */
-class ScanQRCodeContract : ActivityResultContract<Unit, String?>() {
-
-    override fun createIntent(context: Context, input: Unit): Intent {
-        val integrator = IntentIntegrator(context as Activity).apply {
-            setDesiredBarcodeFormats(IntentIntegrator.QR_CODE)
-            setPrompt("Scan a wormhole QR code")
-            setBeepEnabled(false)
-            setOrientationLocked(true)
-        }
-        return integrator.createScanIntent()
-    }
-
-    override fun parseResult(resultCode: Int, intent: Intent?): String? {
-        val result: IntentResult? = IntentIntegrator.parseActivityResult(resultCode, intent)
-        return result?.contents
-    }
-}
 
 /**
  * Result of parsing a wormhole URI.

--- a/android/app/src/main/kotlin/io/sanford/wormhole_william/ui/QrScannerScreen.kt
+++ b/android/app/src/main/kotlin/io/sanford/wormhole_william/ui/QrScannerScreen.kt
@@ -2,7 +2,9 @@ package io.sanford.wormhole_william.ui
 
 import android.Manifest
 import android.content.pm.PackageManager
+import android.util.Size
 import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.camera.core.CameraSelector
@@ -10,6 +12,8 @@ import androidx.camera.core.ExperimentalGetImage
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageProxy
 import androidx.camera.core.Preview
+import androidx.camera.core.resolutionselector.ResolutionSelector
+import androidx.camera.core.resolutionselector.ResolutionStrategy
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import androidx.compose.foundation.background
@@ -64,6 +68,10 @@ fun QrScannerScreen(
     onClose: () -> Unit
 ) {
     val context = LocalContext.current
+
+    // The scanner is an overlay, not a destination: system back must dismiss
+    // it rather than fall through and background the activity.
+    BackHandler(onBack = onClose)
 
     var hasCameraPermission by remember {
         mutableStateOf(
@@ -202,6 +210,19 @@ private fun CameraPreview(
                     }
 
                     val analysis = ImageAnalysis.Builder()
+                        // ML Kit recommends at least 1280x720 for barcode
+                        // scanning; CameraX's default analysis resolution
+                        // (640x480) decodes unreliably on some sensors.
+                        .setResolutionSelector(
+                            ResolutionSelector.Builder()
+                                .setResolutionStrategy(
+                                    ResolutionStrategy(
+                                        Size(1280, 720),
+                                        ResolutionStrategy.FALLBACK_RULE_CLOSEST_HIGHER_THEN_LOWER
+                                    )
+                                )
+                                .build()
+                        )
                         .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
                         .build()
                         .also { it.setAnalyzer(analysisExecutor, analyzer) }

--- a/android/app/src/main/kotlin/io/sanford/wormhole_william/ui/QrScannerScreen.kt
+++ b/android/app/src/main/kotlin/io/sanford/wormhole_william/ui/QrScannerScreen.kt
@@ -1,0 +1,272 @@
+package io.sanford.wormhole_william.ui
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ExperimentalGetImage
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import com.google.mlkit.vision.barcode.BarcodeScannerOptions
+import com.google.mlkit.vision.barcode.BarcodeScanning
+import com.google.mlkit.vision.barcode.common.Barcode
+import com.google.mlkit.vision.common.InputImage
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Full-screen QR scanner built on CameraX (Camera2) + ML Kit barcode scanning.
+ *
+ * This replaces the previous ZXing scanner, whose Camera1 pipeline failed to
+ * decode on some modern high-resolution sensors (e.g. Samsung S22 Ultra): the
+ * preview displayed but the decoder never locked onto the code.
+ *
+ * [onResult] is invoked at most once with the raw contents of the first QR code
+ * detected. [onClose] is invoked when the user dismisses the scanner or denies
+ * the camera permission.
+ */
+@Composable
+fun QrScannerScreen(
+    onResult: (String) -> Unit,
+    onClose: () -> Unit
+) {
+    val context = LocalContext.current
+
+    var hasCameraPermission by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.CAMERA
+            ) == PackageManager.PERMISSION_GRANTED
+        )
+    }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        hasCameraPermission = granted
+        if (!granted) onClose()
+    }
+
+    LaunchedEffect(Unit) {
+        if (!hasCameraPermission) {
+            permissionLauncher.launch(Manifest.permission.CAMERA)
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black)
+    ) {
+        if (hasCameraPermission) {
+            CameraPreview(
+                onBarcode = onResult,
+                onCameraError = {
+                    Toast.makeText(
+                        context,
+                        "Unable to open the camera",
+                        Toast.LENGTH_LONG
+                    ).show()
+                    onClose()
+                },
+                modifier = Modifier.fillMaxSize()
+            )
+
+            Column(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .navigationBarsPadding()
+                    .padding(24.dp)
+            ) {
+                Text(
+                    text = "Point the camera at a wormhole QR code",
+                    color = Color.White,
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                Button(
+                    onClick = onClose,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Cancel")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CameraPreview(
+    onBarcode: (String) -> Unit,
+    onCameraError: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val mainExecutor = remember(context) { ContextCompat.getMainExecutor(context) }
+
+    // Single-thread executor so ML Kit analysis never runs on the main thread.
+    val analysisExecutor = remember { Executors.newSingleThreadExecutor() }
+    val cameraProviderFuture = remember { ProcessCameraProvider.getInstance(context) }
+
+    // Keep the latest callbacks without recreating the analyzer on recomposition.
+    val currentOnBarcode = rememberUpdatedState(onBarcode)
+    val currentOnCameraError = rememberUpdatedState(onCameraError)
+
+    // Fire onBarcode at most once even though frames keep arriving until the
+    // composable leaves the tree.
+    val delivered = remember { AtomicBoolean(false) }
+    // Set once the composable is disposed, so a camera-provider callback that
+    // resolves after disposal does not bind a camera that nothing will unbind.
+    val disposed = remember { AtomicBoolean(false) }
+
+    // Owned here so it can be closed (releases ML Kit native resources).
+    val analyzer = remember {
+        BarcodeAnalyzer { value ->
+            if (delivered.compareAndSet(false, true)) {
+                // Deliver on the main thread, but skip if the scanner was
+                // disposed (e.g. the user tapped Cancel) between detection and
+                // this runnable executing, so a cancelled scan never sets a code.
+                mainExecutor.execute {
+                    if (!disposed.get()) currentOnBarcode.value(value)
+                }
+            }
+        }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            disposed.set(true)
+            // Don't block the main thread: only unbind if the provider is ready.
+            // If it isn't, the pending listener sees `disposed` and skips binding,
+            // so there is nothing to unbind.
+            if (cameraProviderFuture.isDone) {
+                runCatching { cameraProviderFuture.get().unbindAll() }
+            }
+            analysisExecutor.shutdown()
+            analyzer.close()
+        }
+    }
+
+    AndroidView(
+        modifier = modifier,
+        factory = { ctx ->
+            val previewView = PreviewView(ctx).apply {
+                scaleType = PreviewView.ScaleType.FILL_CENTER
+            }
+
+            cameraProviderFuture.addListener({
+                // The composable may have been disposed before the provider
+                // resolved; binding now would leak the camera.
+                if (!disposed.get()) {
+                    val cameraProvider = cameraProviderFuture.get()
+
+                    val preview = Preview.Builder().build().also {
+                        it.setSurfaceProvider(previewView.surfaceProvider)
+                    }
+
+                    val analysis = ImageAnalysis.Builder()
+                        .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                        .build()
+                        .also { it.setAnalyzer(analysisExecutor, analyzer) }
+
+                    try {
+                        cameraProvider.unbindAll()
+                        cameraProvider.bindToLifecycle(
+                            lifecycleOwner,
+                            CameraSelector.DEFAULT_BACK_CAMERA,
+                            preview,
+                            analysis
+                        )
+                    } catch (e: Exception) {
+                        // Binding can fail on a device with no usable back
+                        // camera; surface it and close rather than leaving a
+                        // black overlay. This runs on the main executor.
+                        e.printStackTrace()
+                        currentOnCameraError.value()
+                    }
+                }
+            }, ContextCompat.getMainExecutor(ctx))
+
+            previewView
+        }
+    )
+}
+
+/**
+ * ImageAnalysis.Analyzer that feeds frames to ML Kit and reports the first
+ * QR code's raw value via [onBarcode].
+ */
+private class BarcodeAnalyzer(
+    private val onBarcode: (String) -> Unit
+) : ImageAnalysis.Analyzer {
+
+    private val scanner = BarcodeScanning.getClient(
+        BarcodeScannerOptions.Builder()
+            .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
+            .build()
+    )
+
+    @ExperimentalGetImage
+    override fun analyze(imageProxy: ImageProxy) {
+        val mediaImage = imageProxy.image
+        if (mediaImage == null) {
+            imageProxy.close()
+            return
+        }
+
+        val image = InputImage.fromMediaImage(
+            mediaImage,
+            imageProxy.imageInfo.rotationDegrees
+        )
+
+        scanner.process(image)
+            .addOnSuccessListener { barcodes ->
+                barcodes.firstNotNullOfOrNull { it.rawValue }?.let(onBarcode)
+            }
+            .addOnCompleteListener {
+                imageProxy.close()
+            }
+    }
+
+    /** Releases the ML Kit scanner's native resources. */
+    fun close() {
+        scanner.close()
+    }
+}


### PR DESCRIPTION
## What

Replaces the ZXing-based QR scanner with a CameraX (Camera2) preview plus ML Kit barcode analysis.

## Why

zxing-android-embedded uses the deprecated Camera1 API, which fails to decode QR codes on some modern high-resolution sensors such as the Samsung Galaxy S22 Ultra: the preview and scan line display, but the decoder never locks onto the code. See journeyapps/zxing-android-embedded issues #651 and #652.

## Details

- Remove the zxing-android-embedded dependency and its CaptureActivity.
- Add a full-screen Compose QR scanner built on CameraX with an ML Kit ImageAnalysis analyzer. It includes its own runtime camera-permission request and navigation-bar inset handling for the cancel button.
- Keep QR generation (QRCodeDialog), which only needs ZXing core, by depending on com.google.zxing:core directly.
- Use com.google.mlkit:barcode-scanning (bundled model, no Play Services or network dependency).

## Note on APK size

The bundled ML Kit model increases APK size. The unbundled play-services variant is smaller but requires Google Play Services and a first-run model download. Happy to switch to the unbundled variant if preferred.

## Testing

Built and installed a debug APK on a Samsung Galaxy S22 Ultra (Android 14) and confirmed QR scanning now locks on and decodes immediately, where the previous ZXing scanner did not.
