### PR TITLE
Sanitize received filenames with invalid characters (fixes #29)

### DIFF
--- a/wormhole/filename.go
+++ b/wormhole/filename.go
@@ -1,0 +1,71 @@
+package wormhole
+
+import "strings"
+
+// maxFilenameBytes is the maximum filename length on Android storage (vfat and
+// ext4 both cap at 255 bytes), matching the limit used by
+// android.os.FileUtils.trimFilename.
+const maxFilenameBytes = 255
+
+// sanitizeFilename returns a filename that is safe to write to Android's
+// external storage (the public Downloads folder is FAT/exFAT-backed and is
+// also surfaced through MediaStore, both of which reject certain characters).
+//
+// It replicates android.os.FileUtils.buildValidFatFilename: every character
+// that is invalid in a FAT filename is replaced with '_', then the result is
+// trimmed to 255 bytes. The invalid set is the control characters (0x00-0x1f),
+// 0x7f (DEL), and " * / : < > ? \ |. Empty, "." and ".." are not usable
+// filenames and map to a placeholder.
+//
+// Without this, a sender offering a file whose name contains e.g. ':' would
+// stage to internal storage (ext4 allows it) but then fail to copy to the
+// public Downloads folder.
+func sanitizeFilename(name string) string {
+	if name == "" || name == "." || name == ".." {
+		return "(invalid)"
+	}
+
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range name {
+		if isValidFatFilenameChar(r) {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	return trimFilename(b.String())
+}
+
+// trimFilename shortens name to at most maxFilenameBytes, replicating
+// android.os.FileUtils.trimFilename: runes are removed from the middle and an
+// ellipsis is inserted, which keeps both the start of the name and its
+// extension intact.
+func trimFilename(name string) string {
+	if len(name) <= maxFilenameBytes {
+		return name
+	}
+
+	runes := []rune(name)
+	budget := maxFilenameBytes - len("...")
+	for len(string(runes)) > budget {
+		mid := len(runes) / 2
+		runes = append(runes[:mid], runes[mid+1:]...)
+	}
+	mid := len(runes) / 2
+	return string(runes[:mid]) + "..." + string(runes[mid:])
+}
+
+// isValidFatFilenameChar reports whether r is allowed in a FAT filename,
+// matching android.os.FileUtils.isValidFatFilenameChar.
+func isValidFatFilenameChar(r rune) bool {
+	if r >= 0x00 && r <= 0x1f {
+		return false
+	}
+	switch r {
+	case '"', '*', '/', ':', '<', '>', '?', '\\', '|', 0x7f:
+		return false
+	default:
+		return true
+	}
+}

--- a/wormhole/filename_test.go
+++ b/wormhole/filename_test.go
@@ -26,6 +26,8 @@ func TestSanitizeFilename(t *testing.T) {
 		{"del char replaced", "xy", "x_y"},
 		{"all invalid", `:*?`, "___"},
 		{"directory zip name", "weird:dir.zip", "weird_dir.zip"},
+		{"path traversal is neutralized", "../../evil.sh", ".._.._evil.sh"},
+		{"absolute path is neutralized", "/etc/passwd", "_etc_passwd"},
 		{"empty is invalid", "", "(invalid)"},
 		{"dot is invalid", ".", "(invalid)"},
 		{"dotdot is invalid", "..", "(invalid)"},

--- a/wormhole/filename_test.go
+++ b/wormhole/filename_test.go
@@ -1,0 +1,93 @@
+package wormhole
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeFilename(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain name unchanged", "report.txt", "report.txt"},
+		{"spaces are allowed", "my photo.jpg", "my photo.jpg"},
+		{"unicode is preserved", "café.png", "café.png"},
+		{"colon replaced", "foo:bar.txt", "foo_bar.txt"},
+		{"forward slash replaced", "a/b.txt", "a_b.txt"},
+		{"backslash replaced", `a\b.txt`, "a_b.txt"},
+		{"question mark replaced", "q?.txt", "q_.txt"},
+		{"asterisk replaced", "star*.txt", "star_.txt"},
+		{"double quote replaced", `quote".txt`, "quote_.txt"},
+		{"angle brackets replaced", "a<b>c.txt", "a_b_c.txt"},
+		{"pipe replaced", "a|b.txt", "a_b.txt"},
+		{"control char replaced", "tab\tname", "tab_name"},
+		{"del char replaced", "xy", "x_y"},
+		{"all invalid", `:*?`, "___"},
+		{"directory zip name", "weird:dir.zip", "weird_dir.zip"},
+		{"empty is invalid", "", "(invalid)"},
+		{"dot is invalid", ".", "(invalid)"},
+		{"dotdot is invalid", "..", "(invalid)"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeFilename(tc.in)
+			if got != tc.want {
+				t.Errorf("sanitizeFilename(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeFilenameTrimsLength(t *testing.T) {
+	// Short names are unchanged.
+	if got := sanitizeFilename("short.txt"); got != "short.txt" {
+		t.Errorf("short name changed: %q", got)
+	}
+
+	// Over-long names are trimmed to <= 255 bytes, keeping start + extension.
+	long := strings.Repeat("a", 300) + ".txt"
+	got := sanitizeFilename(long)
+	if len(got) > maxFilenameBytes {
+		t.Errorf("len(result) = %d, want <= %d", len(got), maxFilenameBytes)
+	}
+	if !strings.HasPrefix(got, "a") {
+		t.Errorf("start of name not preserved: %q", got)
+	}
+	if !strings.HasSuffix(got, ".txt") {
+		t.Errorf("extension not preserved: %q", got)
+	}
+	if !strings.Contains(got, "...") {
+		t.Errorf("expected ellipsis marker in %q", got)
+	}
+
+	// A multi-byte (non-ASCII) over-long name must not be truncated mid-rune
+	// and must still be valid UTF-8.
+	longUnicode := strings.Repeat("é", 200) + ".png"
+	gotU := sanitizeFilename(longUnicode)
+	if len(gotU) > maxFilenameBytes {
+		t.Errorf("unicode len(result) = %d, want <= %d", len(gotU), maxFilenameBytes)
+	}
+	if !strings.HasSuffix(gotU, ".png") {
+		t.Errorf("unicode extension not preserved: %q", gotU)
+	}
+}
+
+// A sanitized filename must itself be valid (idempotent and self-consistent).
+func TestSanitizeFilenameIsIdempotent(t *testing.T) {
+	inputs := []string{"foo:bar.txt", "a/b\\c.txt", "café.png", "plain.txt"}
+	for _, in := range inputs {
+		once := sanitizeFilename(in)
+		twice := sanitizeFilename(once)
+		if once != twice {
+			t.Errorf("sanitizeFilename not idempotent for %q: %q -> %q", in, once, twice)
+		}
+		for _, r := range once {
+			if !isValidFatFilenameChar(r) {
+				t.Errorf("sanitizeFilename(%q) = %q still contains invalid char %q", in, once, r)
+			}
+		}
+	}
+}

--- a/wormhole/wormhole.go
+++ b/wormhole/wormhole.go
@@ -177,6 +177,7 @@ func (c *Client) Receive(code string, callback ReceiveCallback) {
 			if msg.Type == wh.TransferDirectory {
 				name += ".zip"
 			}
+			name = sanitizeFilename(name)
 
 			callback.OnFileStart(name, msg.TransferBytes64)
 
@@ -261,6 +262,7 @@ func (c *Client) ReceiveWithAccept(code string, callback ReceiveOfferCallback) {
 			if msg.Type == wh.TransferDirectory {
 				name += ".zip"
 			}
+			name = sanitizeFilename(name)
 
 			pending := &PendingTransfer{
 				client:   c,


### PR DESCRIPTION
Fixes #29.

## What

Sanitizes the filename of a received file before it is written, so files whose names contain characters that are invalid on Android's external storage can be received.

## Why

A sender can offer a file whose name contains characters that are invalid in a FAT/exFAT filename (for example ":"). The file would stage to internal storage (ext4 allows it) but then fail to copy to the public Downloads folder, so the transfer never lands. Issue #29 reported this as a crash on a Pixel 2 XL when receiving a file with a ":" in the name.

## Details

- Add sanitizeFilename, replicating android.os.FileUtils.buildValidFatFilename: control characters (0x00-0x1f), 0x7f, and " * / : < > ? \ | are each replaced with "_". Empty, "." and ".." map to a placeholder.
- Apply it on both receive paths (auto-accept and explicit-accept), after the directory ".zip" suffix is added, so the staged file and the Downloads copy share the same safe name and the accept dialog shows it.
- Add unit tests covering each invalid character, control/DEL characters, preserved spaces and Unicode, ".zip" directory names, the empty/"."/".." cases, and idempotency.

## Testing

go test ./wormhole/ passes. Built a debug APK and confirmed a file sent as "test:file.txt" now saves to Downloads as "test_file.txt" instead of failing.
