### PR TITLE
Harden Go receive paths: close errors, unknown transfer types

### DIFF
--- a/wormhole/pending.go
+++ b/wormhole/pending.go
@@ -78,7 +78,13 @@ func (p *PendingTransfer) Accept() {
 				return
 			}
 		}
-		f.Close()
+		// A buffered write can fail at close (e.g. disk full); report it
+		// rather than declaring a truncated staging file complete.
+		if err := f.Close(); err != nil {
+			os.Remove(path)
+			p.callback.OnError(err.Error())
+			return
+		}
 		p.callback.OnFileComplete(path)
 	}()
 }

--- a/wormhole/wormhole.go
+++ b/wormhole/wormhole.go
@@ -223,8 +223,18 @@ func (c *Client) Receive(code string, callback ReceiveCallback) {
 					return
 				}
 			}
-			f.Close()
+			// A buffered write can fail at close (e.g. disk full); report it
+			// rather than declaring a truncated staging file complete.
+			if err := f.Close(); err != nil {
+				os.Remove(path)
+				callback.OnError(err.Error())
+				return
+			}
 			callback.OnFileComplete(path)
+
+		default:
+			msg.Reject()
+			callback.OnError("unsupported transfer type")
 		}
 	}()
 }
@@ -272,6 +282,11 @@ func (c *Client) ReceiveWithAccept(code string, callback ReceiveOfferCallback) {
 			}
 
 			callback.OnFileOffer(pending)
+
+		default:
+			msg.Reject()
+			cancel()
+			callback.OnError("unsupported transfer type")
 		}
 	}()
 }


### PR DESCRIPTION
Two small robustness fixes in the Go receive paths, found while reviewing the receive flow:

**Report staging-file Close() errors.** Both `Client.Receive` and `PendingTransfer.Accept` ignored the error from the final `f.Close()`. A buffered write can surface a failure (e.g. disk full) only at close, so a truncated staging file could be reported to the UI as `OnFileComplete`. Close errors now remove the partial file and report `OnError`, matching the existing write-error handling.

**Handle unknown transfer types.** The `switch msg.Type` in `Receive` and `ReceiveWithAccept` had no `default`: an unrecognized transfer type fell through without invoking any callback, leaking the cancel context and leaving the UI stuck on "Connecting...". There is now a `default` case that rejects the message and reports an error.

`go test ./...`, `gofmt`, and `go vet` are clean; the gomobile API surface is unchanged, so no AAR-consumer changes are needed.