### PR TITLE
Restore Downloads support on Android 7-9 (regression from the Compose rewrite)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,12 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!-- Pre-Android 10 only: writing received files into the public Downloads
+         folder requires this permission. On Android 10+ the MediaStore path is
+         used instead, which needs no permission, so it is capped at API 28. -->
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
 
     <uses-feature
         android:name="android.hardware.camera"

--- a/android/app/src/main/kotlin/io/sanford/wormhole_william/ui/screens/ReceiveScreen.kt
+++ b/android/app/src/main/kotlin/io/sanford/wormhole_william/ui/screens/ReceiveScreen.kt
@@ -1,5 +1,10 @@
 package io.sanford.wormhole_william.ui.screens
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -32,10 +37,12 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.sanford.wormhole_william.ui.theme.StatusYellow
 import io.sanford.wormhole_william.ui.theme.StatusYellowText
@@ -50,6 +57,28 @@ fun ReceiveScreen(
     val uiState by viewModel.uiState.collectAsState()
     val scrollState = rememberScrollState()
     val clipboardManager = LocalClipboardManager.current
+    val context = LocalContext.current
+
+    // Pre-Android 10 needs WRITE_EXTERNAL_STORAGE to copy the received file
+    // into public Downloads. Request it when the user accepts an offer, and
+    // proceed regardless of the outcome: on denial the copy fails with a
+    // clear status message and the file is kept in internal staging.
+    val writePermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { viewModel.onAcceptFile() }
+
+    val acceptFile = {
+        val needsWritePermission = Build.VERSION.SDK_INT < Build.VERSION_CODES.Q &&
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE
+            ) != PackageManager.PERMISSION_GRANTED
+        if (needsWritePermission) {
+            writePermissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+        } else {
+            viewModel.onAcceptFile()
+        }
+    }
 
     Column(
         modifier = Modifier
@@ -234,7 +263,7 @@ fun ReceiveScreen(
                 }
             },
             confirmButton = {
-                Button(onClick = viewModel::onAcceptFile) {
+                Button(onClick = acceptFile) {
                     Text("Accept")
                 }
             },

--- a/android/app/src/main/kotlin/io/sanford/wormhole_william/ui/viewmodel/ReceiveViewModel.kt
+++ b/android/app/src/main/kotlin/io/sanford/wormhole_william/ui/viewmodel/ReceiveViewModel.kt
@@ -7,6 +7,8 @@ import io.sanford.wormhole_william.repository.WormholeRepository
 import io.sanford.wormhole_william.util.detectMimeType
 import io.sanford.wormhole_william.util.formatBytes
 import io.sanford.wormhole_william.util.notifyDownloadManager
+import io.sanford.wormhole_william.util.queryDownloadDisplayName
+import java.io.File
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -123,7 +125,22 @@ class ReceiveViewModel(application: Application) : AndroidViewModel(application)
                         )
 
                         val statusMsg = result.fold(
-                            onSuccess = { _ -> "File saved to Downloads: $fileName" },
+                            onSuccess = { uri ->
+                                // The copy to Downloads succeeded, so the
+                                // internal staging copy is no longer needed.
+                                // Removing it also prevents a later same-named
+                                // transfer from being wrongly blocked as
+                                // "already exists". Only delete on success: if
+                                // the copy failed, the staging file is the only
+                                // copy of the received file and must be kept.
+                                runCatching { File(state.path).delete() }
+                                val savedName = context.queryDownloadDisplayName(uri) ?: fileName
+                                if (savedName != fileName) {
+                                    "Saved to Downloads as $savedName (renamed to avoid overwriting an existing file)"
+                                } else {
+                                    "File saved to Downloads: $savedName"
+                                }
+                            },
                             onFailure = { e -> "File received but failed to copy to Downloads: ${e.message}" }
                         )
 

--- a/android/app/src/main/kotlin/io/sanford/wormhole_william/ui/viewmodel/ReceiveViewModel.kt
+++ b/android/app/src/main/kotlin/io/sanford/wormhole_william/ui/viewmodel/ReceiveViewModel.kt
@@ -9,12 +9,14 @@ import io.sanford.wormhole_william.util.formatBytes
 import io.sanford.wormhole_william.util.notifyDownloadManager
 import io.sanford.wormhole_william.util.queryDownloadDisplayName
 import java.io.File
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import wormhole.PendingTransfer
 
 data class ReceiveUiState(
@@ -115,34 +117,40 @@ class ReceiveViewModel(application: Application) : AndroidViewModel(application)
                         val context = getApplication<Application>()
                         val fileName = _uiState.value.pendingFileName
                         val fileSize = _uiState.value.pendingFileSize
-                        val mimeType = detectMimeType(state.path)
 
-                        val result = context.notifyDownloadManager(
-                            name = fileName,
-                            path = state.path,
-                            mimeType = mimeType,
-                            size = fileSize
-                        )
+                        // The copy to Downloads is file I/O proportional to
+                        // the transfer size; keep it off the main thread so a
+                        // large received file cannot freeze the UI (ANR).
+                        val statusMsg = withContext(Dispatchers.IO) {
+                            val mimeType = detectMimeType(state.path)
 
-                        val statusMsg = result.fold(
-                            onSuccess = { uri ->
-                                // The copy to Downloads succeeded, so the
-                                // internal staging copy is no longer needed.
-                                // Removing it also prevents a later same-named
-                                // transfer from being wrongly blocked as
-                                // "already exists". Only delete on success: if
-                                // the copy failed, the staging file is the only
-                                // copy of the received file and must be kept.
-                                runCatching { File(state.path).delete() }
-                                val savedName = context.queryDownloadDisplayName(uri) ?: fileName
-                                if (savedName != fileName) {
-                                    "Saved to Downloads as $savedName (renamed to avoid overwriting an existing file)"
-                                } else {
-                                    "File saved to Downloads: $savedName"
-                                }
-                            },
-                            onFailure = { e -> "File received but failed to copy to Downloads: ${e.message}" }
-                        )
+                            val result = context.notifyDownloadManager(
+                                name = fileName,
+                                path = state.path,
+                                mimeType = mimeType,
+                                size = fileSize
+                            )
+
+                            result.fold(
+                                onSuccess = { uri ->
+                                    // The copy to Downloads succeeded, so the
+                                    // internal staging copy is no longer needed.
+                                    // Removing it also prevents a later same-named
+                                    // transfer from being wrongly blocked as
+                                    // "already exists". Only delete on success: if
+                                    // the copy failed, the staging file is the only
+                                    // copy of the received file and must be kept.
+                                    runCatching { File(state.path).delete() }
+                                    val savedName = context.queryDownloadDisplayName(uri) ?: fileName
+                                    if (savedName != fileName) {
+                                        "Saved to Downloads as $savedName (renamed to avoid overwriting an existing file)"
+                                    } else {
+                                        "File saved to Downloads: $savedName"
+                                    }
+                                },
+                                onFailure = { e -> "File received but failed to copy to Downloads: ${e.message}" }
+                            )
+                        }
 
                         _uiState.update {
                             it.copy(

--- a/android/app/src/main/kotlin/io/sanford/wormhole_william/util/DownloadManager.kt
+++ b/android/app/src/main/kotlin/io/sanford/wormhole_william/util/DownloadManager.kt
@@ -11,6 +11,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
+import android.provider.OpenableColumns
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import io.sanford.wormhole_william.R
@@ -19,6 +20,9 @@ import java.io.FileInputStream
 
 private const val CHANNEL_ID = "wormhole_downloads"
 private const val NOTIFICATION_ID = 1001
+
+// Max filename length on Android storage (vfat/ext4 both cap at 255 bytes).
+private const val MAX_FILENAME_BYTES = 255
 
 /**
  * Registers a file with Android's Download Manager so it appears in the Downloads app.
@@ -47,6 +51,76 @@ fun Context.notifyDownloadManager(
         e.printStackTrace()
         Result.failure(e)
     }
+}
+
+/**
+ * Resolves the actual display name of a saved download. On Android 10+ the
+ * MediaStore automatically appends a numeric suffix (e.g. "report (1).pdf")
+ * when a file with the same name already exists in Downloads, so the saved
+ * name may differ from the requested one.
+ */
+fun Context.queryDownloadDisplayName(uri: Uri): String? {
+    // file:// URIs (legacy path) carry the name directly; ContentResolver does
+    // not answer OpenableColumns for them.
+    if (uri.scheme == "file") return uri.lastPathSegment
+    return try {
+        contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+            ?.use { cursor ->
+                val idx = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (idx >= 0 && cursor.moveToFirst()) cursor.getString(idx) else null
+            }
+    } catch (e: Exception) {
+        null
+    }
+}
+
+/**
+ * Atomically creates and returns a new (empty) File in [dir], appending
+ * " (1)", " (2)", ... before the extension on collision, mirroring MediaStore's
+ * auto-rename so the legacy (pre-Android 10) path does not overwrite an existing
+ * download. Uses File.createNewFile() (an atomic create-if-absent) rather than a
+ * check-then-create, so a racing writer cannot cause an overwrite.
+ */
+private fun uniqueDownloadFile(dir: File, name: String): File {
+    val dot = name.lastIndexOf('.')
+    val base = if (dot > 0) name.substring(0, dot) else name
+    val ext = if (dot > 0) name.substring(dot) else ""
+
+    var candidate = File(dir, name)
+    var i = 1
+    while (!candidate.createNewFile()) {
+        val suffix = " ($i)"
+        // Keep the suffixed name within the filesystem's 255-byte limit by
+        // trimming the base; without this a near-max-length name could exceed
+        // the limit once the collision suffix is appended.
+        val room = MAX_FILENAME_BYTES - utf8Len(suffix) - utf8Len(ext)
+        candidate = File(dir, trimToBytes(base, room) + suffix + ext)
+        i++
+    }
+    return candidate
+}
+
+private fun utf8Len(s: String): Int = s.toByteArray(Charsets.UTF_8).size
+
+/**
+ * Trims s to at most maxBytes UTF-8 bytes without splitting a Unicode code
+ * point (so the result is always valid).
+ */
+private fun trimToBytes(s: String, maxBytes: Int): String {
+    if (maxBytes <= 0) return ""
+    if (utf8Len(s) <= maxBytes) return s
+
+    val sb = StringBuilder()
+    var bytes = 0
+    val it = s.codePoints().iterator()
+    while (it.hasNext()) {
+        val chunk = String(Character.toChars(it.nextInt()))
+        val chunkBytes = utf8Len(chunk)
+        if (bytes + chunkBytes > maxBytes) break
+        sb.append(chunk)
+        bytes += chunkBytes
+    }
+    return sb.toString()
 }
 
 private fun Context.copyToDownloadsViaMediaStore(
@@ -98,19 +172,29 @@ private fun Context.copyToDownloadsLegacy(
     // Copy to public Downloads directory
     @Suppress("DEPRECATION")
     val downloadsDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
-    val destFile = File(downloadsDir, name)
+    downloadsDir.mkdirs()
+    // Pick a non-colliding name so an existing download is not overwritten
+    // (MediaStore does this automatically on Android 10+).
+    val destFile = uniqueDownloadFile(downloadsDir, name)
 
-    FileInputStream(sourcePath).use { input ->
-        destFile.outputStream().use { output ->
-            input.copyTo(output)
+    try {
+        FileInputStream(sourcePath).use { input ->
+            destFile.outputStream().use { output ->
+                input.copyTo(output)
+            }
         }
+    } catch (e: Exception) {
+        // uniqueDownloadFile already created (reserved) destFile; remove the
+        // 0-byte/partial file so a failed copy doesn't leave junk in Downloads.
+        destFile.delete()
+        throw e
     }
 
     // Register with DownloadManager
     val downloadManager = getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
     @Suppress("DEPRECATION")
     downloadManager.addCompletedDownload(
-        name,
+        destFile.name,
         "Received via Wormhole William",
         true,
         mimeType,

--- a/android/app/src/main/kotlin/io/sanford/wormhole_william/util/DownloadManager.kt
+++ b/android/app/src/main/kotlin/io/sanford/wormhole_william/util/DownloadManager.kt
@@ -14,6 +14,7 @@ import android.provider.MediaStore
 import android.provider.OpenableColumns
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.FileProvider
 import io.sanford.wormhole_william.R
 import java.io.File
 import java.io.FileInputStream
@@ -60,8 +61,8 @@ fun Context.notifyDownloadManager(
  * name may differ from the requested one.
  */
 fun Context.queryDownloadDisplayName(uri: Uri): String? {
-    // file:// URIs (legacy path) carry the name directly; ContentResolver does
-    // not answer OpenableColumns for them.
+    // Defensive: no caller currently produces file:// URIs, but ContentResolver
+    // cannot answer OpenableColumns for them, so read the name directly.
     if (uri.scheme == "file") return uri.lastPathSegment
     return try {
         contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
@@ -203,7 +204,10 @@ private fun Context.copyToDownloadsLegacy(
         true
     )
 
-    return Uri.fromFile(destFile)
+    // Hand out a content:// URI via FileProvider: file:// URIs are rejected
+    // by other apps since API 24 (FileUriExposedException), which would break
+    // the completion notification's ACTION_VIEW intent.
+    return FileProvider.getUriForFile(this, "$packageName.fileprovider", destFile)
 }
 
 private fun Context.showDownloadCompleteNotification(name: String, uri: Uri, mimeType: String) {

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -6,4 +6,9 @@
     <files-path
         name="files"
         path="." />
+    <!-- Public Downloads folder, used on pre-Android 10 to hand out
+         content:// URIs for files saved by the legacy download path. -->
+    <external-path
+        name="downloads"
+        path="Download/" />
 </paths>

--- a/wormhole/pending.go
+++ b/wormhole/pending.go
@@ -36,14 +36,12 @@ func (p *PendingTransfer) Accept() {
 	go func() {
 		defer p.cancel()
 
+		// dataDir is an internal, ephemeral staging area. The Kotlin layer
+		// copies the result into the user-visible Downloads folder and then
+		// deletes this staging file. Overwrite any leftover staging file
+		// (e.g. from a previous interrupted transfer) rather than failing:
+		// os.Create truncates an existing file.
 		path := filepath.Join(p.client.dataDir, p.name)
-
-		// Check if file exists
-		if _, err := os.Stat(path); err == nil {
-			p.msg.Reject()
-			p.callback.OnError("file already exists: " + p.name)
-			return
-		}
 
 		f, err := os.Create(path)
 		if err != nil {

--- a/wormhole/wormhole.go
+++ b/wormhole/wormhole.go
@@ -180,15 +180,11 @@ func (c *Client) Receive(code string, callback ReceiveCallback) {
 
 			callback.OnFileStart(name, msg.TransferBytes64)
 
-			// Save to dataDir
+			// Save to dataDir, an internal staging area. The Android layer
+			// copies the result to the user-visible Downloads folder and then
+			// removes this file, so overwrite any leftover staging file rather
+			// than failing: os.Create truncates an existing file.
 			path := filepath.Join(c.dataDir, name)
-
-			// Check if file exists
-			if _, err := os.Stat(path); err == nil {
-				msg.Reject()
-				callback.OnError("file already exists: " + name)
-				return
-			}
 
 			f, err := os.Create(path)
 			if err != nil {


### PR DESCRIPTION
**Note: stacked on #62** - this branch includes #62's commits because both rework `DownloadManager.kt`. Once #62 merges, this PR's diff collapses to the single 'Restore Downloads support on Android 7-9' commit.

## The regression

Receiving files is currently broken on every Android 7-9 device (API 24-28, minSdk is 24). The transfer itself succeeds, but the copy from internal staging to public Downloads always fails with a permission error, so the file is stranded in `filesDir` where the user cannot see it, and the UI reports *"File received but failed to copy to Downloads: Permission denied"*.

This is a regression from the December 2025 Compose rewrite: f75a88a and 6f9a63b (2021, fixing #9/#11/#13) added the `WRITE_EXTERNAL_STORAGE` manifest entry and a runtime permission request (`WriteFilePerm.java`), and 52fda08 removed them along with the rest of the Gio code without a replacement. v1.0.x through v1.0.13 worked on these devices; every v2.x build has not.

## The fix (all inert on Android 10+)

- Declare `WRITE_EXTERNAL_STORAGE` with `maxSdkVersion="28"` - the permission does not exist at all on API 29+ installs, where the MediaStore path needs no permission.
- Request it at file-accept time, pre-Q only, using the same Compose `RequestPermission` launcher pattern as the camera permission. Denial is handled by the existing failure branch (clear status message, staging copy kept) - no rationale dialogs or settings deep-links.
- Return a FileProvider `content://` URI from the legacy path instead of `Uri.fromFile`: with targetSdk 35, `file://` URIs are rejected by receiving apps since API 24, which broke the completion notification's ACTION_VIEW intent. Adds the missing `external-path` entry to `file_paths.xml`.

## Verification

Tested on API 24 and API 28 arm64 emulator images (Google APIs), sending real transfers from the wormhole-william CLI:

- Accept -> system permission dialog appears -> **Allow** -> file lands in `/sdcard/Download/` with byte-exact content, staging copy deleted, status "File saved to Downloads".
- Accept -> **Deny** -> no crash, status "File received but failed to copy to Downloads: Permission denied", staging copy preserved.
- Same-named file re-received (API 28) -> saved as `wormtest (1).txt` with the renamed-notice status (exercises #62's collision handling on the legacy path).
- Completion notification's PendingIntent carries `content://io.sanford.wormhole_william.fileprovider/downloads/...`.
- API 29+ regression check: the permission is absent from modern installs and the request gate is `SDK_INT < Q`; Gradle unit tests pass.

Being honest about scale: this app's live pre-Android-10 user base is probably small (this has been broken for ~7 months with no issue filed). But the fix is ~50 gated lines, and any Android 7-9 user who has installed v2.x is currently stuck with a non-working receive - only a fixed minSdk-24 update can reach them.

## Alternative

If you'd rather drop pre-Android-10 support instead, the cleaner form of that decision is raising `minSdk` to 29 and deleting `copyToDownloadsLegacy` and its helpers (~100 lines). Happy to send that PR instead - your call; what seems worst is the current state, where the Play listing advertises Android 7 compatibility but receive cannot work there.